### PR TITLE
Fix dynamic year in footer

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,7 +14,7 @@ const siteDomain = import.meta.env.SITE_DOMAIN ?? "";
       <p class="mt-2"><Content /></p>
     </div>
     <footer class="text-md absolute bottom-0 left-0 w-full bg-black/50 p-0 text-center text-light">
-      ©2024 {siteDomain}
+      ©{new Date().getFullYear()} {siteDomain}
     </footer>
   </main>
 </Layout>


### PR DESCRIPTION
## Summary
- replace `©2024` with the current year in the homepage footer

## Testing
- `npm test` *(fails: run-p not found)*

------
https://chatgpt.com/codex/tasks/task_b_683adfdb6b24832f8ae4f5e4cbb1a967