### PR TITLE
Fix lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,12 +36,6 @@ jobs:
       - name: Install Nix
         uses: nixbuild/nix-quick-install-action@v26
 
-      - name: Restore and cache Nix store
-        uses: nix-community/cache-nix-action@v5
-        with:
-          primary-key: ${{ runner.os }}-nix-store-${{ hashFiles('**/*.nix') }}
-          restore-prefixes-first-match: ${{ runner.os }}-nix-store-
-
       - name: Install treefmt
         run: nix profile install 'nixpkgs#treefmt'
 


### PR DESCRIPTION
## Summary
- remove failing `cache-nix-action` from lint workflow

## Testing
- `bun run test` *(fails: run-p not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ae5d8ff58832f8a0b8cf586b62905