### PR TITLE
Update to Node 24

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/mise.toml
+++ b/mise.toml
@@ -3,4 +3,4 @@ _.file = [".env.local"]
 _.path = ['./node_modules/.bin']
 
 [tools]
-node = '18.19.0'
+node = '24'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "packageManager": "bun@1.0.0",
   "engines": {
-    "node": ">=16.0.0 <=20.x.x"
+    "node": ">=24.0.0 <=24.x.x"
   },
   "scripts": {
     "husky:install": "husky install .husky",
@@ -54,7 +54,7 @@
     "@radix-ui/colors": "^3.0.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@t3-oss/env-core": "^0.10.1",
-    "@types/node": "20.14.11",
+    "@types/node": "24.0.0",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
     "astro": "^4.11.5",


### PR DESCRIPTION
## Summary
- update Node version to 24 in project settings
- bump `@types/node` and engines field
- use Node 24 in CI build workflow

## Testing
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_b_683aeaca64ac832f881f6aa5b48253ff