### PR TITLE
ci: update setup-bun to v2 in workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,9 @@ jobs:
           node-version-file: "package.json"
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,7 +29,9 @@ jobs:
           node-version-file: "package.json"
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,9 @@ jobs:
           node-version: 20
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
## Summary
• Update GitHub Actions workflows to use oven-sh/setup-bun@v2 with latest version

## Test plan
- [ ] Verify all workflows pass with updated bun setup action
- [ ] Confirm build, lint, and test workflows execute successfully

🤖 Generated with [Claude Code](https://claude.ai/code)