### PR TITLE
feat: add custom domains and consolidate env config

### DIFF
--- a/.env
+++ b/.env
@@ -4,6 +4,10 @@
 #/----------------------------------------------------------/
 DOTENV_PUBLIC_KEY="02a24255a5999e3f8f746b6954d15de973fa6d826910a173dc5b808cde07e06f93"
 
+# App
+APP_NAME=jey3dayo.net
+SITE_DOMAIN=jey3dayo.net
+
 # Cloudflare
 CLOUDFLARE_API_TOKEN="encrypted:BKiecLahuo+0kDe8I8o2rmFN2qytjOpnCI9VtR7Z2OGvFkRAJGEcIJQC+qk466UBXTtqdGC5qhfXlAgNtBuiOFyhL0cDqSh4O4vm1IrVhOAwOJvqW+Sks/y+naNrBSrIGThfonJMWCoF44bY33HAEetpFSs1X+cBVr1kb2n0jfqCkCPeATrt1Qw="
 CLOUDFLARE_ACCOUNT_ID="encrypted:BKCYmza6Fd5VAuDU5zNBnznf8KsCO8iKUtV083P3Xw7zjdHKwjtjnjBCGSIxw0Efzq6MtcxKFu7gYbTVH8/RqstoTDQwiBrZt7WsK4ebXRxHETp5X2SdQHmZLGolhVaR8zkm6DOmIjDNI/KwcFM5o17pB4567GwMAGsDKVIIkRvF"

--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@
 #/----------------------------------------------------------/
 DOTENV_PUBLIC_KEY="02a24255a5999e3f8f746b6954d15de973fa6d826910a173dc5b808cde07e06f93"
 
-# App
+# App (keep in sync with wrangler.jsonc vars)
 APP_NAME=jey3dayo.net
 SITE_DOMAIN=jey3dayo.net
 

--- a/.env.local
+++ b/.env.local
@@ -1,3 +1,0 @@
-APP_NAME=jey3dayo.net
-SITE_DOMAIN=jey3dayo.net
-

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 .wrangler
 .dev.vars
 .secrets.json
+.vercel
 
 # dependencies
 node_modules/

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [env]
-_.file = [".env.local"]
+_.file = [".env"]
 _.path = ['./node_modules/.bin']
 
 [tools]

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,6 +9,10 @@
     "binding": "ASSETS",
   },
   "observability": { "enabled": true },
+  "routes": [
+    { "pattern": "jey3dayo.net", "custom_domain": true },
+    { "pattern": "www.jey3dayo.net", "custom_domain": true },
+  ],
   "vars": {
     "APP_NAME": "jey3dayo.net",
     "SITE_DOMAIN": "jey3dayo.net",


### PR DESCRIPTION
## Summary

- `wrangler.jsonc`: `jey3dayo.net` と `www.jey3dayo.net` のカスタムドメインを `routes` で設定
- `.env`: `APP_NAME` / `SITE_DOMAIN` を追加（`.env.local` から移行）
- `mise.toml`: `_.file` を `.env.local` → `.env` に変更
- `.env.local`: 削除（`.env` に統合）
- `.gitignore`: `.vercel` を追加

## Test plan

- [x] `bun run build` 成功（エラー・警告 0 件）
- [x] `wrangler deploy --dry-run` 成功（WARNING なし）